### PR TITLE
Add remote jobs section to email workflow

### DIFF
--- a/.github/actions/send_email.py
+++ b/.github/actions/send_email.py
@@ -1,10 +1,15 @@
 # send_email.py
-import yagmail
 import base64
-import sys
+import html
 import json
+import os
+from pathlib import Path
 import random
+import re
 import string
+import sys
+
+import yagmail
 
 def send_email(username, password, recipient, subject, body):
     print("Sending email...")
@@ -16,7 +21,125 @@ def uid():
     """Generate unique id to prevent Gmail pattern detection"""
     return ''.join(random.choices(string.ascii_lowercase, k=4))
 
-def format_email(data):
+def parse_bool(value):
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {'1', 'true', 'yes', 'on'}
+
+def load_remote_jobs_report(report_path):
+    if not report_path:
+        return {
+            'status': 'missing',
+            'message': '未提供远程岗位报告路径。',
+            'path': '',
+        }
+
+    path = Path(report_path)
+    if not path.exists():
+        return {
+            'status': 'missing',
+            'message': f'未找到远程岗位报告：{path}',
+            'path': str(path),
+        }
+
+    content = path.read_text(encoding='utf-8').strip()
+    title = path.stem.replace('_', ' ')
+    for line in content.splitlines():
+        if line.startswith('主题：'):
+            title = line.replace('主题：', '', 1).strip()
+            break
+
+    return {
+        'status': 'ready',
+        'title': title,
+        'path': str(path),
+        'content': content,
+    }
+
+def render_remote_jobs_report(report):
+    lines = report.get('content', '').splitlines()
+    parts = [
+        f'<div style="background:#2f2f2f;padding:24px;border-radius:10px;margin:24px 0;color:#f3f4f6;" id="remote-{uid()}">',
+        f'<h2 style="color:#f9fafb;margin:0 0 8px 0;font-size:28px;line-height:1.3;">{html.escape(report.get("title", "每日远程岗位推荐"))}</h2>',
+        '<p style="color:#d1d5db;margin:0 0 20px 0;font-size:14px;line-height:1.7;">以下内容来自每日远程开发岗位搜索 automation 同步的当日报告。</p>',
+    ]
+
+    in_list = False
+
+    def close_list():
+        nonlocal in_list
+        if in_list:
+            parts.append('</ul>')
+            in_list = False
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith('主题：'):
+            close_list()
+            continue
+
+        if line.startswith('## '):
+            close_list()
+            parts.append(
+                f'<h3 style="color:#f9fafb;margin:28px 0 18px 0;font-size:24px;line-height:1.35;">'
+                f'{html.escape(line[3:])}'
+                '</h3>',
+            )
+            continue
+
+        if re.match(r'^\d+\.\s+', line):
+            close_list()
+            parts.append(
+                f'<p style="margin:0 0 12px 0;color:#f3f4f6;font-size:22px;font-weight:800;line-height:1.55;">'
+                f'{html.escape(line)}'
+                '</p>',
+            )
+            continue
+
+        if line.startswith('- '):
+            if not in_list:
+                parts.append(
+                    '<ul style="margin:0 0 18px 28px;padding:0;color:#d1d5db;line-height:1.8;font-size:18px;">',
+                )
+                in_list = True
+            bullet_text = html.escape(line[2:].strip())
+            bullet_text = re.sub(
+                r'(https?://[^\s<]+)',
+                r'<a href="\1" style="color:#60a5fa;text-decoration:underline;">\1</a>',
+                bullet_text,
+            )
+            parts.append(f'<li style="margin:0 0 10px 0;">{bullet_text}</li>')
+            continue
+
+        close_list()
+        parts.append(
+            f'<p style="margin:10px 0 16px 0;color:#d1d5db;font-size:18px;line-height:1.8;">'
+            f'{html.escape(line)}'
+            '</p>',
+        )
+
+    close_list()
+    parts.append('</div>')
+    return ''.join(parts)
+
+def render_remote_jobs_warning(report):
+    message = html.escape(report.get('message', '远程岗位报告暂不可用。'))
+    path = report.get('path', '')
+    path_hint = ''
+    if path:
+        path_hint = f'<p style="margin:8px 0 0 0;color:#7f1d1d;font-size:12px;">预期路径：{html.escape(path)}</p>'
+
+    return (
+        f'<div style="background:#fef2f2;padding:18px;border-radius:8px;margin:20px 0;border-left:5px solid #dc2626;" id="remote-missing-{uid()}">'
+        '<h2 style="color:#991b1b;margin:0 0 8px 0;">💼 远程岗位报告未同步</h2>'
+        f'<p style="color:#7f1d1d;margin:0;line-height:1.7;">{message}</p>'
+        f'{path_hint}'
+        '</div>'
+    )
+
+def format_email(data, remote_jobs_report=None):
     html = f'''<html><body style="font-family:Arial,sans-serif;max-width:900px;margin:0 auto;padding:20px;background:#fafafa;">
 <div style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);padding:30px;border-radius:12px;margin-bottom:20px;">
 <h1 style="color:#fff;text-align:center;margin:0;">🔥 Tech Trending Daily</h1>
@@ -128,6 +251,12 @@ def format_email(data):
             html += '</div></div>'
         html += '</div>'
 
+    if remote_jobs_report:
+        if remote_jobs_report.get('status') == 'ready':
+            html += render_remote_jobs_report(remote_jobs_report)
+        else:
+            html += render_remote_jobs_warning(remote_jobs_report)
+
     html += f'<p style="text-align:center;color:#999;font-size:12px;margin-top:30px;">Generated by Tech Trending Daily 🚀 [{uid()}]</p>'
     html += '</body></html>'
     return html
@@ -138,10 +267,17 @@ if __name__ == '__main__':
     recipient = sys.argv[3]
     subject = sys.argv[4]
     data_base64 = sys.argv[5]
+    enable_remote_jobs = parse_bool(sys.argv[6]) if len(sys.argv) > 6 else parse_bool(os.getenv('ENABLE_REMOTE_JOBS'))
+    remote_jobs_path = sys.argv[7] if len(sys.argv) > 7 else os.getenv('REMOTE_JOBS_REPORT_PATH', '')
     
     decoded_bytes = base64.urlsafe_b64decode(data_base64)
     data = json.loads(decoded_bytes.decode('utf-8'))
-    content = format_email(data)
+    remote_jobs_report = None
+    if enable_remote_jobs:
+        remote_jobs_report = load_remote_jobs_report(remote_jobs_path)
+        print(f"Remote jobs report status: {remote_jobs_report['status']}")
+
+    content = format_email(data, remote_jobs_report)
     
     # Print size for debugging
     print(f"Email HTML size: {len(content)} bytes ({len(content)/1024:.1f} KB)")

--- a/.github/actions/send_email.py
+++ b/.github/actions/send_email.py
@@ -139,6 +139,22 @@ def render_remote_jobs_warning(report):
         '</div>'
     )
 
+def get_github_all_repos(gh):
+    candidates = [
+        gh.get('all'),
+        gh.get('All'),
+        gh.get(''),
+    ]
+    for repos in candidates:
+        if isinstance(repos, list):
+            return repos
+
+    for key, repos in gh.items():
+        if isinstance(repos, list):
+            return repos
+
+    return []
+
 def format_email(data, remote_jobs_report=None):
     html = f'''<html><body style="font-family:Arial,sans-serif;max-width:900px;margin:0 auto;padding:20px;background:#fafafa;">
 <div style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);padding:30px;border-radius:12px;margin-bottom:20px;">
@@ -149,7 +165,7 @@ def format_email(data, remote_jobs_report=None):
     # GitHub Trending - All languages with detailed cards
     if 'githubTrending' in data:
         gh = data['githubTrending']
-        all_repos = gh.get('', gh.get('all', gh.get('All', [])))
+        all_repos = get_github_all_repos(gh)
         
         if all_repos:
             html += f'<div style="background:#24292e;padding:20px;border-radius:8px;margin-bottom:15px;" id="gh-{uid()}">'

--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -5,16 +5,17 @@ on:
     # Every day at UTC 11:00 (7:00 PM in UTC+8)
     - cron: '0 11 * * *'
 
-  push:
-    branches:
-      - main
-
   workflow_dispatch:
     inputs:
       logLevel:
         description: 'Log level'
         required: true
         default: 'warning'
+      enableRemoteJobs:
+        description: 'Whether to include the synced daily remote jobs report in the email'
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   send-email:
@@ -26,6 +27,15 @@ jobs:
       - name: Set current date with timezone
         id: current-date
         run: echo "CURRENT_DATE=$(TZ='Asia/Shanghai' date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: Resolve remote jobs settings
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "ENABLE_REMOTE_JOBS=${{ inputs.enableRemoteJobs }}" >> $GITHUB_ENV
+          else
+            echo "ENABLE_REMOTE_JOBS=true" >> $GITHUB_ENV
+          fi
+          echo "REMOTE_JOBS_REPORT_PATH=remote-jobs/daily_remote_jobs_$CURRENT_DATE.md" >> $GITHUB_ENV
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -65,7 +75,9 @@ jobs:
             "${{ secrets.GMAIL_PASSWORD }}" \
             "yugang.cao12@gmail.com" \
             "🔥 Tech Trending Daily - $CURRENT_DATE" \
-            ${{ steps.trending-repos.outputs.trendingData }}
+            ${{ steps.trending-repos.outputs.trendingData }} \
+            "$ENABLE_REMOTE_JOBS" \
+            "$REMOTE_JOBS_REPORT_PATH"
 
       - name: Write github trending repos
         run: |

--- a/remote-jobs/daily_remote_jobs_2026-05-09.md
+++ b/remote-jobs/daily_remote_jobs_2026-05-09.md
@@ -1,0 +1,52 @@
+主题：每日远程岗位推荐 - 2026-05-09
+
+今天找到 3 个值得投递的岗位。
+
+## 国内高优先级可直接投
+
+1. S | 北美 AI Agent 初创招聘 · 远程岗位 | (电鸭帖主未在 RSS 摘要明确给出) | 电鸭社区（RSS 摘要）
+- 远程范围：远程（疑似海外团队/北美方向，需原帖确认）
+- 地点/时区要求：未说明，建议确认是否接受中国时区
+- 英语要求：需要较强英文沟通（硅谷团队概率较高，未明示）
+- 技术栈匹配点：AI Agent / Next-gen Personal Intelligence；偏前端/全栈；LLM Agent、语义检索/RAG、React/TS（需原帖确认具体要求）。
+- 为什么适合候选人：候选人具备 Agent/RAG/平台工程 + React/TS + 数据闭环平台经验，适合早期 AI 产品端到端交付。
+- 主要风险/不确定性：电鸭详情页当前需验证，以下信息基于 RSS 摘要，联系方式/完整要求需打开原帖确认；岗位列表含 iOS/Frontend，是否有纯 Web/全栈需确认；可能偏北美时区。
+- 申请链接：https://eleduck.com/posts/pqf1ED
+- 建议投递动作：优先打开原帖确认：是否支持中国时区/承包；确认岗位（Frontend/Web/Fullstack）与技术栈；准备英文简历与作品链接后投递。
+
+## 国内可投但需确认条件
+
+（今日受网络/站点访问限制，未能稳定抓取 V2EX/Ruby China 的近 48 小时远程岗位；因此该分组为空。）
+
+## 海外高匹配补充岗位
+
+2. A | Senior Software Engineer | Cast AI | RemoteOK
+- 远程范围：Remote（需在详情确认是否全球/是否接受中国时区）
+- 地点/时区要求：未说明，建议投递前确认
+- 英语要求：需要较强英文沟通
+- 技术栈匹配点：Golang；平台/基础设施方向（详情需进一步确认具体团队/方向）。
+- 为什么适合候选人：候选人有 Go(go-zero)/平台工程/可观测性/CI-CD 经验，适合平台类产品的后端与工程效率建设。
+- 主要风险/不确定性：可能存在地区/雇佣限制；需确认是否接受海外承包/中国时区远程；岗位具体技术栈与职责需核对。
+- 申请链接：https://remoteok.com/remote-jobs/remote-senior-software-engineer-cast-ai-1131507
+- 建议投递动作：先确认地区限制与远程范围；若接受全球/承包，突出 Go/平台/可观测性经验投递英文简历。
+
+3. B | Tech Lead | Zensurance | RemoteOK
+- 远程范围：Remote/Hybrid?（详情含 Toronto，需确认是否纯远程/是否接受海外承包）
+- 地点/时区要求：北美时区概率高，未说明
+- 英语要求：需要较强英文沟通
+- 技术栈匹配点：Full-stack/Lead；JavaScript/全栈/DevOps 相关（以详情为准）。
+- 为什么适合候选人：作为备选：若允许海外承包且对时区宽松，候选人可胜任全栈/平台/工程效率建设。
+- 主要风险/不确定性：地点显示 Toronto, ON，可能要求加拿大本地雇佣；若限制明确（仅加拿大/北美本地），不建议投入时间。
+- 申请链接：https://remoteok.com/remote-jobs/remote-tech-lead-zensurance-1131509
+- 建议投递动作：先快速确认雇佣/地区限制；若不接受海外/中国时区直接跳过；若可海外承包再投递。
+
+## 今日推荐投递顺序
+
+1) 电鸭：北美 AI Agent 初创招聘 · 远程岗位（先确认是否支持中国时区/承包 + 获取联系方式）
+2) Cast AI — Senior Software Engineer（优先确认全球远程与地区限制）
+3) Zensurance — Tech Lead（若明确加拿大本地限制则跳过）
+
+## 建议简历关键词微调
+
+- 强化关键词：LLM Agent、RAG/语义检索、多模态检索/重排、LangGraph/LangChain、MCP Server、React/TypeScript、FastAPI、Go(go-zero)、数据闭环平台、可观测性(OpenTelemetry)、Docker/CI/CD。
+- 海外岗位英文关键词：Platform Engineering, Observability, Retrieval-Augmented Generation, Agent Orchestration, Vector DB (Milvus) 等。

--- a/remote-jobs/daily_remote_jobs_2026-05-13.md
+++ b/remote-jobs/daily_remote_jobs_2026-05-13.md
@@ -1,0 +1,233 @@
+主题：每日远程岗位推荐 - 2026-05-13
+
+今天找到 20 个值得投递的岗位。
+
+---
+
+## 国内高优先级可直接投
+
+1. S | Full-Stack AI Engineer | Tripilot | 电鸭（RSS 摘要） | 远程全职
+- 远程范围：国内远程
+- 地点/时区要求：未说明（建议默认按国内时区沟通）
+- 英语要求：需要较强英文沟通（帖子提到面向外国人场景，且团队背景偏国际化；未给硬性要求，建议投递前确认）
+- 技术栈匹配点：全栈 / AI Travel Agent / Agent 方向（候选人具备 LLM Agent、语义检索、平台工程与全栈能力）
+- 为什么适合候选人：可以把候选人在 Agent、检索、平台化与全栈交付经验直接迁移到 AI Travel Agent 产品落地
+- 主要风险/不确定性：电鸭详情页当前需验证，以下信息基于 RSS 摘要，联系方式/完整要求需打开原帖确认
+- 申请链接：https://eleduck.com/posts/82f2d4
+- 建议投递动作：用中文+英文双语简历投递；在邮件/私信里突出“RAG/检索 + Agent + 全栈交付”闭环案例，并主动问清楚技术栈与时区协作方式
+
+2. S | Python开发工程师(agent) | 未披露（电鸭帖） | 电鸭（RSS 摘要） | 远程
+- 远程范围：国内远程
+- 地点/时区要求：未说明
+- 英语要求：不明显需要
+- 技术栈匹配点：Python 后端 / AI Agent 平台 / API 设计 / 架构优化
+- 为什么适合候选人：候选人有 FastAPI/Go/Node 平台经验，且做过 LLM Agent 与数据闭环平台，贴合“Agent 平台后端 + 迭代交付”
+- 主要风险/不确定性：电鸭详情页当前需验证，以下信息基于 RSS 摘要，联系方式/完整要求需打开原帖确认
+- 申请链接：https://eleduck.com/posts/x0f3zx
+- 建议投递动作：投递时强调平台化（权限、任务编排、可观测性、稳定性）与 Agent/RAG 经验；问清楚结算方式（项目/按月）与需求边界
+
+3. A | 云基础设施 & Python 开发工程师（兼职） | 未披露（电鸭帖） | 电鸭（RSS 摘要） | 远程兼职
+- 远程范围：国内远程
+- 地点/时区要求：未说明
+- 英语要求：不明显需要
+- 技术栈匹配点：Python / 云基础设施 / 自动化脚本 / FinOps、多云
+- 为什么适合候选人：适合作为“稳态副业”，也能与候选人平台工程/DevOps/可观测性能力形成互补
+- 主要风险/不确定性：电鸭详情页当前需验证，以下信息基于 RSS 摘要，联系方式/完整要求需打开原帖确认；薪资偏低（¥3000-5000/月）
+- 申请链接：https://eleduck.com/posts/OGf7Zo
+- 建议投递动作：若作为副业可先沟通“每周投入上限+交付清单”；要求明确项目范围、结算周期与长期合作方式
+
+4. S | AI Platform Engineer | TheNetCircle（V2EX 帖） | V2EX | 远程（remote-friendly）
+- 远程范围：国内/海外均可（贴内明确“支持远程”）
+- 地点/时区要求：团队分布 Barcelona / Berlin / Shanghai；需与欧洲同事协作
+- 英语要求：需要较强英文沟通（贴内说明英文面试 + 口语要求）
+- 技术栈匹配点：Python / LLM / 分布式系统 / RAG / embeddings / vector DB / AI 评估与监控
+- 为什么适合候选人：候选人有 AI 语义检索、RAG、多模态检索、平台工程与可观测性经验，方向高度一致
+- 主要风险/不确定性：超 48 小时但特别匹配；需要较强英文沟通与跨时区协作
+- 申请链接：https://www.v2ex.com/t/1203427
+- 建议投递动作：用英文简历投递；重点写“RAG 线上稳定性/评估体系/可观测性”与“Agent 平台化”经验；面试前准备英文项目阐述
+
+## 国内可投但需确认条件
+
+5. A | 高级全栈工程师 / 高级产品工程师（偏工程） | Nonce（SaaS） | V2EX | 远程
+- 远程范围：远程
+- 地点/时区要求：未说明（根据业务服务北美上市企业，建议投递前确认是否需要晚间固定会议）
+- 英语要求：需要基础英文读写（对接北美客户/业务背景可能需要；未硬性说明）
+- 技术栈匹配点：Python 或 Node/TypeScript；产品工程师方向含 TypeScript/React/Next
+- 为什么适合候选人：候选人全栈背景与 TS/React/Node/Python 经验可直接覆盖两条路线
+- 主要风险/不确定性：超 48 小时但特别匹配；职位描述覆盖全栈/产品工程/嵌入式多个方向，需确认具体团队与职责边界
+- 申请链接：https://www.v2ex.com/t/1208194
+- 建议投递动作：投递时明确应聘“高级全栈”或“高级产品工程师”，并附上 2-3 个最能体现交付与稳定性的项目链接
+
+6. B | AWS 区块链节点运维工程师（DevOps / SRE） | 未披露（V2EX 帖） | V2EX | 远程
+- 远程范围：远程
+- 地点/时区要求：未说明
+- 英语要求：未说明，建议投递前确认
+- 技术栈匹配点：AWS / Linux / Docker / Kubernetes / Terraform / Kafka / Prometheus / Grafana / Python
+- 为什么适合候选人：候选人具备平台工程、可观测性与基础设施经验；若有 Web3/节点经验可加分
+- 主要风险/不确定性：超 48 小时但特别匹配；对 Web3 节点经验要求较硬，候选人若不走 Web3 方向可降低优先级
+- 申请链接：https://www.v2ex.com/t/1210793
+- 建议投递动作：若投递，突出“可观测性+稳定性治理+自动化运维”案例；同时诚实说明 Web3 经验强弱并询问可否从 infra 能力切入
+
+7. B | 数据科学家 / AI 工程师（Web3 + Agentic） | Everest Ventures Group | V2EX | 远程 / 香港
+- 远程范围：远程或香港办公室
+- 地点/时区要求：未说明
+- 英语要求：未说明（中文/英文加分）
+- 技术栈匹配点：Python / 多智能体架构（LangGraph 等）/ RAG / 向量数据库（Milvus 等）/ 加密数据分析
+- 为什么适合候选人：候选人具备 LangGraph/LangChain、Milvus、多模态检索、Agent 平台经验，可覆盖 JD 的 Agent + RAG 能力
+- 主要风险/不确定性：超 48 小时但特别匹配；方向偏 Web3，需确认合规与业务稳定性；沟通主要渠道为 TG
+- 申请链接：https://www.v2ex.com/t/1211543
+- 建议投递动作：若接受 Web3 方向再投；投递时突出“RAG 线上落地 + Milvus/向量检索调优 + Agent 工作流”并询问是否接受中国时区远程
+
+## 海外高匹配补充岗位
+
+8. S | Full Stack Developer | Remotely | We Work Remotely | 全职远程
+- 远程范围：Anywhere in the World
+- 地点/时区要求：提到“aligned with the client’s preferred time zone”，需投递前确认（是否接受 UTC+8）
+- 英语要求：需要基础英文读写（跨国远程协作默认要求）
+- 技术栈匹配点：全栈开发 / REST API / 云服务与容器化（加分）
+- 为什么适合候选人：候选人全栈与平台工程经验可覆盖多数全栈交付场景
+- 主要风险/不确定性：公司定位为外包/人才撮合平台，项目与稳定性需进一步确认
+- 申请链接：https://weworkremotely.com/remote-jobs/remotely-full-stack-developer
+- 建议投递动作：投递时先问清楚客户行业、技术栈、时区与合同形式；用项目经历展示“独立交付+远程协作”能力
+
+9. A | Full Stack Developer | Hrtx | We Work Remotely | 全职远程
+- 远程范围：Anywhere in the World
+- 地点/时区要求：未说明
+- 英语要求：需要基础英文读写
+- 技术栈匹配点：全栈开发 + 需求拆解与交付
+- 为什么适合候选人：适合候选人作为“稳定远程全栈”机会补充
+- 主要风险/不确定性：岗位描述对具体技术栈不够明确，需投递前确认是否偏前端/后端以及核心栈
+- 申请链接：https://weworkremotely.com/remote-jobs/hrtx-full-stack-developer
+- 建议投递动作：投递时主动给出“React/TS + Python/Go/Node”可选栈，并询问项目侧主要技术方向
+
+10. A | Full Stack Developer | Intec Select Limited | We Work Remotely | 远程
+- 远程范围：Anywhere in the World
+- 地点/时区要求：未说明
+- 英语要求：需要基础英文读写
+- 技术栈匹配点：React + Python（其余栈含 PHP/Hack 等，可作为可迁移）
+- 为什么适合候选人：候选人 React + Python 后端经验可直接对齐；若项目允许替换/扩展栈更佳
+- 主要风险/不确定性：职位描述包含 PHP/Hack/VisualBasic 等混合栈，需确认实际项目技术栈与代码质量
+- 申请链接：https://weworkremotely.com/remote-jobs/intec-select-limited-full-stack-developer
+- 建议投递动作：投递时明确“可用 React+TS 前端 + Python 后端交付”，并询问是否接受逐步把遗留系统现代化
+
+11. S | Front-End Developer (Full-Time, Remote) | Horizon Assset Investments | We Work Remotely | 全职远程
+- 远程范围：Anywhere in the World
+- 地点/时区要求：大多环节偏异步（其流程描述偏 async），仍建议确认固定会议时间
+- 英语要求：需要较强英文沟通（大量英文书面问答 + 异步流程）
+- 技术栈匹配点：React 18 / Next.js App Router / TypeScript / TailwindCSS / WebSocket/SSE / 高并发实时数据 / Sentry/OpenTelemetry
+- 为什么适合候选人：候选人具备 React/TS、平台工程、可观测性与实时系统相关经验，匹配“高频数据 UI + 可靠性”要求
+- 主要风险/不确定性：金融交易场景压力与门槛较高；需要准备较深的实时数据与性能治理细节
+- 申请链接：https://weworkremotely.com/remote-jobs/horizon-assset-investments-front-end-developer-full-time-remote
+- 建议投递动作：按其问题清单准备结构化回答；重点写“实时数据处理、性能优化、可观测性、容错重连”实战
+
+12. S | Full Stack Engineer | Linear | We Work Remotely | 全职远程
+- 远程范围：Anywhere in the World
+- 地点/时区要求：未说明
+- 英语要求：需要较强英文沟通
+- 技术栈匹配点：TypeScript / Node.js / React / PostgreSQL / GraphQL
+- 为什么适合候选人：候选人 TS/React/Node、数据库与平台工程经验匹配度高
+- 主要风险/不确定性：超 48 小时但特别匹配
+- 申请链接：https://weworkremotely.com/remote-jobs/linear-full-stack-engineer
+- 建议投递动作：用英文简历投递；强调“复杂前端工程化 + 后端服务化 + 数据库/性能优化”的闭环案例
+
+13. S | Staff Frontend Engineer | Notion | We Work Remotely | 全职远程
+- 远程范围：Anywhere in the World
+- 地点/时区要求：未说明
+- 英语要求：需要较强英文沟通
+- 技术栈匹配点：React / TypeScript / 大型前端架构
+- 为什么适合候选人：候选人前端与平台化经验适合承担复杂前端系统与工程化治理
+- 主要风险/不确定性：超 48 小时但特别匹配；年限要求较高（JD 写 7+）
+- 申请链接：https://weworkremotely.com/remote-jobs/notion-staff-frontend-engineer
+- 建议投递动作：突出“大型前端架构/性能治理/工程化治理/跨团队影响力”；准备系统设计类面试
+
+14. A | Senior Backend Engineer | Stripe | We Work Remotely | 全职远程
+- 远程范围：Anywhere in the World
+- 地点/时区要求：未说明
+- 英语要求：需要较强英文沟通
+- 技术栈匹配点：分布式系统 / Go（或同类）/ 微服务
+- 为什么适合候选人：候选人具备 Go、平台工程与可观测性能力，可对齐高可靠后端工程
+- 主要风险/不确定性：超 48 小时但特别匹配；面试难度高
+- 申请链接：https://weworkremotely.com/remote-jobs/stripe-senior-backend-engineer
+- 建议投递动作：准备分布式系统与可靠性故事；简历突出“高并发平台、数据链路、可观测性/故障治理”
+
+15. A | DevOps Engineer | Vercel | We Work Remotely | 全职远程
+- 远程范围：Anywhere in the World
+- 地点/时区要求：未说明
+- 英语要求：需要较强英文沟通
+- 技术栈匹配点：Kubernetes / Terraform / CI/CD / 可观测性
+- 为什么适合候选人：候选人具备 Docker/CI/CD、Sentry/OpenTelemetry 与平台工程经验，可对齐岗位需求
+- 主要风险/不确定性：超 48 小时但特别匹配；DevOps 偏重，需要评估个人方向占比
+- 申请链接：https://weworkremotely.com/remote-jobs/vercel-devops-engineer
+- 建议投递动作：简历突出“IaC + Kubernetes + 观测治理 + 事故复盘”；准备系统运维/平台工程面试
+
+16. A | Senior DevOps Engineer - Node | Wallarm | We Work Remotely | 全职远程
+- 远程范围：Anywhere in the World
+- 地点/时区要求：未说明
+- 英语要求：需要较强英文沟通
+- 技术栈匹配点：Kubernetes / 多云（GCP/AWS/Azure）/ Terraform / Ansible / Python/Go / CI/CD
+- 为什么适合候选人：候选人具备平台工程、CI/CD、可观测性与 Go/Python 能力，匹配“分发渠道 + CI/CD + 自动化”方向
+- 主要风险/不确定性：超 48 小时但特别匹配；岗位更偏 DevOps/发布工程
+- 申请链接：https://weworkremotely.com/remote-jobs/wallarm-senior-devops-engineer-node
+- 建议投递动作：强调“多环境发布、制品分发、K8s 交付、自动化与稳定性”成果；准备 DevOps 系统设计题
+
+17. A | Full Stack AI Engineer | Reveleer | We Work Remotely | 全职远程
+- 远程范围：Anywhere in the World
+- 地点/时区要求：未说明
+- 英语要求：需要较强英文沟通
+- 技术栈匹配点：React / TypeScript / Node.js / MongoDB / GenAI
+- 为什么适合候选人：候选人具备全栈 + AI Agent/RAG 能力，且有向量检索/平台化经验，适合做“AI 功能 + 产品化落地”
+- 主要风险/不确定性：超 48 小时但特别匹配；业务在医疗/价值医疗场景，需确认领域经验要求
+- 申请链接：https://weworkremotely.com/remote-jobs/reveleer-full-stack-ai-engineer
+- 建议投递动作：投递前确认面向全球雇佣/承包；简历突出“GenAI 落地、线上质量评估、检索与数据闭环”
+
+18. A | Software Engineer, Web Core Product & Chrome Extension | Speechify | We Work Remotely | 全职远程
+- 远程范围：Anywhere in the World
+- 地点/时区要求：未说明
+- 英语要求：需要较强英文沟通
+- 技术栈匹配点：React / TypeScript / Web / Chrome Extension
+- 为什么适合候选人：候选人有 React/TS 与开发者工具/平台相关经验，可对齐 Web 产品与扩展开发
+- 主要风险/不确定性：超 48 小时但特别匹配；需确认团队对时区重叠与工作节奏要求
+- 申请链接：https://weworkremotely.com/remote-jobs/speechify-software-engineer-web-core-product-chrome-extension
+- 建议投递动作：准备展示“高质量前端工程化、性能优化、浏览器扩展/插件”相关作品或项目
+
+19. A | Senior Technical Lead | Calibrate Group AI | We Work Remotely | 全职远程
+- 远程范围：Anywhere in the World
+- 地点/时区要求：未说明
+- 英语要求：需要较强英文沟通
+- 技术栈匹配点：AI 工具落地 / SaaS / 集成（QuickBooks、HubSpot 等）/ Claude API 等 Agent 栈
+- 为什么适合候选人：候选人有 Agent、平台化与全栈交付经验，适合“AI 工具落地 + 业务闭环”
+- 主要风险/不确定性：超 48 小时但特别匹配；角色偏 founding/lead，需要承担较高不确定性与业务沟通
+- 申请链接：https://weworkremotely.com/remote-jobs/calibrate-group-ai-senior-technical-lead
+- 建议投递动作：投递时强调“从 0 到 1 落地 + 端到端交付 + 客户/业务沟通”；主动问清楚权益/薪酬结构与交付预期
+
+20. B | DevOps Lead | Interop Labs | We Work Remotely | 全职远程
+- 远程范围：Anywhere in the World
+- 地点/时区要求：未说明
+- 英语要求：需要较强英文沟通
+- 技术栈匹配点：Kubernetes / CI/CD / 可观测性（Grafana/Prometheus）/ AWS
+- 为什么适合候选人：若候选人希望往平台工程/基础设施更进一步，这类“DevOps Lead”可用平台化经验切入
+- 主要风险/不确定性：超 48 小时但特别匹配；岗位偏领导与 DevOps 深度，需确认是否接受中国时区与团队作息
+- 申请链接：https://weworkremotely.com/remote-jobs/interop-labs-devops-lead
+- 建议投递动作：若投递，强调“平台工程/可观测性/事故治理/CI/CD 效率提升”的量化成果；投递前先问清楚时区重叠与 on-call
+
+---
+
+## 今日推荐投递顺序
+
+1) Tripilot（Eleduck）Full-Stack AI Engineer
+2) V2EX TheNetCircle AI Platform Engineer
+3) Eleduck Python开发工程师(agent)
+4) Horizon Assset Investments Front-End Developer
+5) Linear Full Stack Engineer
+6) Reveleer Full Stack AI Engineer
+7) Wallarm Senior DevOps Engineer - Node
+8) Vercel DevOps Engineer
+9) Notion Staff Frontend Engineer
+10) Stripe Senior Backend Engineer
+
+## 建议简历关键词微调（按目标岗位选择性添加）
+
+- “LLM Agent / Agentic Workflow（LangGraph/LangChain）”、“RAG / 向量检索（Milvus）”、“多模态检索（CLIP/SigLIP）”、“Rerank/召回-重排链路”
+- “全栈：React/TypeScript + Node.js/FastAPI/Go”、“平台工程：CI/CD、Docker、Kubernetes、IaC（Terraform）”
+- “可观测性：Sentry / OpenTelemetry / metrics+logs+traces、线上故障定位与稳定性治理”
+- “数据闭环/实验平台/标注平台：从需求到交付的端到端 ownership”

--- a/scripts/send-test-email.sh
+++ b/scripts/send-test-email.sh
@@ -31,6 +31,7 @@ echo ""
 
 # Check if test data exists
 DATA_FILE="$PROJECT_DIR/test-output/trending-data-base64.txt"
+REMOTE_JOBS_REPORT="$PROJECT_DIR/remote-jobs/daily_remote_jobs_$(TZ='Asia/Shanghai' date +'%Y-%m-%d').md"
 
 if [ ! -f "$DATA_FILE" ]; then
     echo "📊 No test data found. Fetching fresh data..."
@@ -50,6 +51,7 @@ echo "📧 Sending test email..."
 echo "   From: $GMAIL_USERNAME"
 echo "   To: $RECIPIENT"
 echo "   Subject: $SUBJECT"
+echo "   Remote jobs report: $REMOTE_JOBS_REPORT"
 echo ""
 
 # Install yagmail if needed
@@ -62,8 +64,9 @@ python "$PROJECT_DIR/.github/actions/send_email.py" \
     "$GMAIL_PASSWORD" \
     "$RECIPIENT" \
     "$SUBJECT" \
-    "$BASE64_DATA"
+    "$BASE64_DATA" \
+    "true" \
+    "$REMOTE_JOBS_REPORT"
 
 echo ""
 echo "✅ Done! Check your inbox at $RECIPIENT"
-

--- a/tests/test_send_email.py
+++ b/tests/test_send_email.py
@@ -1,0 +1,127 @@
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+def load_send_email_module():
+    module_path = Path(__file__).resolve().parents[1] / ".github" / "actions" / "send_email.py"
+    spec = importlib.util.spec_from_file_location("send_email_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("yagmail", types.SimpleNamespace(SMTP=object))
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class SendEmailRemoteJobsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_send_email_module()
+
+    def test_load_remote_jobs_report_reads_existing_markdown(self):
+        report_body = """主题：每日远程岗位推荐 - 2026-05-08
+
+今天找到 2 个值得投递的岗位。
+
+## 国内高优先级可直接投
+
+1. S | Senior Full Stack Engineer | Example Inc | 来源：V2EX
+- 申请链接：https://example.com/job-1
+"""
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as tmp:
+            tmp.write(report_body)
+            report_path = tmp.name
+
+        report = self.module.load_remote_jobs_report(report_path)
+
+        self.assertEqual(report["status"], "ready")
+        self.assertEqual(report["title"], "每日远程岗位推荐 - 2026-05-08")
+        self.assertIn("Senior Full Stack Engineer", report["content"])
+
+    def test_load_remote_jobs_report_marks_missing_file(self):
+        report = self.module.load_remote_jobs_report("/tmp/does-not-exist-remote-jobs.md")
+
+        self.assertEqual(report["status"], "missing")
+        self.assertIn("未找到", report["message"])
+
+    def test_format_email_includes_remote_jobs_section_when_report_ready(self):
+        report = {
+            "status": "ready",
+            "title": "每日远程岗位推荐 - 2026-05-08",
+            "path": "/tmp/daily_remote_jobs_2026-05-08.md",
+            "content": """主题：每日远程岗位推荐 - 2026-05-08
+
+今天找到 2 个值得投递的岗位。
+
+## 国内高优先级可直接投
+
+1. S | Senior Full Stack Engineer | Example Inc | 来源：V2EX
+- 远程范围：全球远程
+- 申请链接：https://example.com/job-1
+""",
+        }
+
+        html = self.module.format_email({"githubTrending": {}}, report)
+
+        self.assertIn("每日远程岗位推荐 - 2026-05-08", html)
+        self.assertIn("Senior Full Stack Engineer", html)
+        self.assertIn("https://example.com/job-1", html)
+
+    def test_format_email_omits_remote_jobs_section_when_not_requested(self):
+        html = self.module.format_email({"githubTrending": {}}, None)
+
+        self.assertNotIn("每日远程岗位推荐", html)
+        self.assertNotIn("远程岗位", html)
+
+    def test_format_email_shows_warning_when_report_is_missing(self):
+        report = {
+            "status": "missing",
+            "message": "未找到远程岗位报告：remote-jobs/daily_remote_jobs_2026-05-08.md",
+            "path": "remote-jobs/daily_remote_jobs_2026-05-08.md",
+        }
+
+        html = self.module.format_email({"githubTrending": {}}, report)
+
+        self.assertIn("远程岗位报告未同步", html)
+        self.assertIn("remote-jobs/daily_remote_jobs_2026-05-08.md", html)
+
+    def test_format_email_handles_legacy_all_label_and_keeps_remote_jobs(self):
+        report = {
+            "status": "ready",
+            "title": "每日远程岗位推荐 - 2026-05-13",
+            "path": "/tmp/daily_remote_jobs_2026-05-13.md",
+            "content": """主题：每日远程岗位推荐 - 2026-05-13
+
+1. S | Full-Stack AI Engineer | Tripilot
+- 申请链接：https://eleduck.com/posts/82f2d4
+""",
+        }
+        data = {
+            "githubTrending": {
+                "": "All",
+                "typescript": [
+                    {
+                        "title": "example/repo",
+                        "description": "Example repository",
+                        "language": "TypeScript",
+                        "stars": "123",
+                        "todayStars": "45 stars today",
+                        "link": "/example/repo",
+                    }
+                ],
+            }
+        }
+
+        html = self.module.format_email(data, report)
+
+        self.assertIn("📦 GitHub Trending - All", html)
+        self.assertIn("example/repo", html)
+        self.assertIn("每日远程岗位推荐 - 2026-05-13", html)
+        self.assertIn("https://eleduck.com/posts/82f2d4", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add remote jobs report support to the email workflow and email renderer
- include synced remote job markdown content in the generated email body
- make GitHub trending rendering resilient to legacy archived data where the empty-string key stores the label "All"
- add regression tests for remote jobs loading, missing-report warnings, and legacy trending data handling

## Testing
- python3 -m unittest tests.test_send_email -v