### PR TITLE
Move daily workflow off the hour

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -2,8 +2,8 @@ name: Send Tech Trending Daily via Gmail
 
 on:
   schedule:
-    # Every day at UTC 11:00 (7:00 PM in UTC+8)
-    - cron: '0 11 * * *'
+    # Every day at UTC 11:17 (7:17 PM in UTC+8)
+    - cron: '17 11 * * *'
 
   workflow_dispatch:
     inputs:

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ name: Send Tech Trending Daily via Gmail
 
 on:
   schedule:
-    # Every day at UTC 11:00 (7:00 PM in UTC+8)
-    - cron: '0 11 * * *'
+    # Every day at UTC 11:17 (7:17 PM in UTC+8)
+    - cron: '17 11 * * *'
   workflow_dispatch: # Allow manual trigger
 
 jobs:


### PR DESCRIPTION
## Summary
- move the scheduled workflow from 19:00 to 19:17 CST
- keep README cron example aligned with the workflow

## Why
GitHub Actions schedule triggers are getting delayed at the start of the hour, so moving off :00 should reduce queueing.